### PR TITLE
Add post meta box with "Push to NPR" button

### DIFF
--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -54,6 +54,8 @@ require_once( DS_NPR_PLUGIN_DIR . '/settings.php' );
 require_once( DS_NPR_PLUGIN_DIR . '/classes/NPRAPIWordpress.php');
 
 require_once( DS_NPR_PLUGIN_DIR . '/get_stories.php');
+require_once( DS_NPR_PLUGIN_DIR . '/meta-boxes.php');
+
 //add the cron to get stories
 register_activation_hook( DS_NPR_PLUGIN_DIR . '/ds-npr-api.php', 'ds_npr_story_activation' );
 add_action( 'npr_ds_hourly_cron', array ( 'DS_NPR_API','ds_npr_story_cron_pull' ) );
@@ -156,3 +158,18 @@ function ds_npr_create_post_type() {
 		)
 	);
 }
+
+function ds_npr_add_meta_boxes() {
+	$screen = get_current_screen();
+	$push_url = get_option( 'ds_npr_api_push_url' );
+	if ( $screen->id == 'post' && ! empty( $push_url ) ) {
+		global $post;
+		add_meta_box(
+			'ds_npr_document_meta',
+			'NPR Story API',
+			'ds_npr_publish_meta_box',
+			'post', 'side'
+		);
+	}
+}
+add_action('add_meta_boxes', 'ds_npr_add_meta_boxes');

--- a/meta-boxes.php
+++ b/meta-boxes.php
@@ -1,0 +1,20 @@
+<?php
+
+function ds_npr_publish_meta_box($post) {
+	$helper_text = 'Push this story to NPR:';
+	$is_disabled = ($post->post_status != 'publish');
+	if ($is_disabled) {
+		$helper_text = 'Publish this story in order to push it to NPR.';
+	}
+	$attrs = array('id' => 'ds-npr-update-push');
+	if ($is_disabled)
+		$attrs['disabled'] = 'disabled';
+?>
+	<div id="ds-npr-publish-actions">
+		<p class="helper-text"><?php echo $helper_text; ?></p>
+<?php
+	submit_button( 'Push to NPR', 'large', 'ds_npr_update_push', false, $attrs );
+?>
+	</div>
+<?php
+}

--- a/push_story.php
+++ b/push_story.php
@@ -9,11 +9,14 @@ require_once ( 'classes/NPRAPIWordpress.php' );
  * @param unknown_type $post
  */
 function npr_push ( $post_ID, $post ) {
+	if ( ! isset( $_POST['ds_npr_update_push'] ) ) {
+		return false;
+	}
+
 	$push_post_type = get_option( 'ds_npr_push_post_type' );
 	if ( empty( $push_post_type ) ) {
 		$push_post_type = 'post';
 	}
-
 
 	//if the push url isn't set, don't even try to push.
 	$push_url = get_option( 'ds_npr_api_push_url' );


### PR DESCRIPTION
This adds a "Push to NPR" button on the post edit screen, requiring users to explicitly indicate that a story should be sent to the NPR Story API.

This change fixes a bug/incompatibility with the PMP WordPress plugin. The bug in question would result in duplicate NPR stories being pushed to the NPR API when an NPR story was imported via the PMP plugin. This would occur because the NPR plugin was configured to automatically push all posts to the API upon save.